### PR TITLE
Badge looks wrong when right-aligned

### DIFF
--- a/Views/MKNumberBadgeView/MKNumberBadgeView.h
+++ b/Views/MKNumberBadgeView/MKNumberBadgeView.h
@@ -44,6 +44,8 @@
 	
 	BOOL _shadow;
 	BOOL _shine;
+    
+    CGSize _shadowOffset;
 	
 	UITextAlignment _alignment;
 }
@@ -53,6 +55,9 @@
 
 // Indicates whether the badge view draws a dhadow or not.
 @property (assign,nonatomic) BOOL shadow;
+
+// The offset for the shadow, if there is one.
+@property (assign,nonatomic) CGSize shadowOffset;
 
 // Indicates whether the badge view should be drawn with a shine
 @property (assign,nonatomic) BOOL shine;

--- a/Views/MKNumberBadgeView/MKNumberBadgeView.m
+++ b/Views/MKNumberBadgeView/MKNumberBadgeView.m
@@ -36,6 +36,7 @@
 @implementation MKNumberBadgeView
 @synthesize value=_value;
 @synthesize shadow=_shadow;
+@synthesize shadowOffset=_shadowOffset;
 @synthesize shine=_shine;
 @synthesize font=_font;
 @synthesize fillColor=_fillColor;
@@ -75,6 +76,7 @@
 	self.pad = 4;
 	self.font = [UIFont boldSystemFontOfSize:16];
 	self.shadow = YES;
+	self.shadowOffset = CGSizeMake(0, -3);
 	self.shine = YES;
 	self.alignment = UITextAlignmentCenter;
 	self.fillColor = [UIColor redColor];
@@ -122,11 +124,11 @@
 	CGContextSetLineWidth( curContext, lineWidth );
 	CGContextSetStrokeColorWithColor(  curContext, self.strokeColor.CGColor  );
 	CGContextSetFillColorWithColor( curContext, self.fillColor.CGColor );
-    
-    // Line stroke straddles the path, so we need to account for the outer portion
-    badgeRect.size.width += ceilf( lineWidth / 2 );
-    badgeRect.size.height += ceilf( lineWidth / 2 );
-		
+	
+	// Line stroke straddles the path, so we need to account for the outer portion
+	badgeRect.size.width += ceilf( lineWidth / 2 );
+	badgeRect.size.height += ceilf( lineWidth / 2 );
+	
 	CGPoint ctm;
 	
 	switch (self.alignment) 
@@ -149,9 +151,7 @@
 	{
 		CGContextSaveGState( curContext );
 
-		CGSize blurSize;
-		blurSize.width = 0;
-		blurSize.height = -3;
+		CGSize blurSize = self.shadowOffset;
 		UIColor* blurColor = [[UIColor blackColor] colorWithAlphaComponent:0.5];
 		
 		CGContextSetShadowWithColor( curContext, blurSize, 4, blurColor.CGColor );


### PR DESCRIPTION
The badge getting clipped by 1pt when right-aligned because the stroke is _centered_ on the badge path, not entirely inside it. This fixes that, and also allows the user to specify in which direction the shadow should be cast.
