### PR TITLE
Hide When Zero

### DIFF
--- a/Views/MKNumberBadgeView/MKNumberBadgeView.h
+++ b/Views/MKNumberBadgeView/MKNumberBadgeView.h
@@ -73,4 +73,7 @@
 // is approximate, as the font geometry might effectively slightly increase or decrease the apparent pad.
 @property (nonatomic) NSUInteger pad;
 
+// If YES, the badge will be hidden when the value is 0
+@property (nonatomic) BOOL hideWhenZero;
+
 @end

--- a/Views/MKNumberBadgeView/MKNumberBadgeView.m
+++ b/Views/MKNumberBadgeView/MKNumberBadgeView.m
@@ -45,6 +45,7 @@
 @synthesize alignment;
 @dynamic badgeSize;
 @synthesize pad;
+@synthesize hideWhenZero;
 
 - (id)initWithFrame:(CGRect)frame 
 {
@@ -82,6 +83,7 @@
 	self.fillColor = [UIColor redColor];
 	self.strokeColor = [UIColor whiteColor];
 	self.textColor = [UIColor whiteColor];
+    self.hideWhenZero = NO;
 	
 	self.backgroundColor = [UIColor clearColor];
 }
@@ -260,6 +262,15 @@
 - (void)setValue:(NSUInteger)inValue
 {
 	_value = inValue;
+    
+    if (self.hideWhenZero == YES && _value == 0)
+    {
+        self.hidden = YES;
+    }
+    else
+    {
+        self.hidden = NO;
+    }
 	
 	[self setNeedsDisplay];
 }


### PR DESCRIPTION
Added property, hideWhenZero, to cause the badge to be hidden when its value is set to zero when the property is set to YES
