### PR TITLE
An enum was renamed in iOS 6. Use the new name.

### DIFF
--- a/Views/MKNumberBadgeView/MKNumberBadgeView.m
+++ b/Views/MKNumberBadgeView/MKNumberBadgeView.m
@@ -94,7 +94,7 @@
 	self.shadowOffset = CGSizeMake(0, 3);
 	self.shadowColor = [[UIColor blackColor] colorWithAlphaComponent:0.5];
 	self.shine = YES;
-	self.alignment = UITextAlignmentCenter;
+	self.alignment = NSTextAlignmentCenter;
 	self.fillColor = [UIColor redColor];
 	self.strokeColor = [UIColor whiteColor];
 	self.strokeWidth = 2.0;
@@ -152,13 +152,13 @@
 	{
 		case NSTextAlignmentJustified:
 		case NSTextAlignmentNatural:
-		case UITextAlignmentCenter:
+		case NSTextAlignmentCenter:
 			ctm = CGPointMake( round((viewBounds.size.width - badgeRect.size.width)/2), round((viewBounds.size.height - badgeRect.size.height)/2) );
 			break;
-		case UITextAlignmentLeft:
+		case NSTextAlignmentLeft:
 			ctm = CGPointMake( 0, round((viewBounds.size.height - badgeRect.size.height)/2) );
 			break;
-		case UITextAlignmentRight:
+		case NSTextAlignmentRight:
 			ctm = CGPointMake( (viewBounds.size.width - badgeRect.size.width), round((viewBounds.size.height - badgeRect.size.height)/2) );
 			break;
 	}


### PR DESCRIPTION
I started doing this in a previous commit, but clearly missed some.
