### PR TITLE
show the right way of adding a badge to a UISegmentedControl

### DIFF
--- a/Sample App/iPhoneMK Sample App/NumberBadgeViewController.h
+++ b/Sample App/iPhoneMK Sample App/NumberBadgeViewController.h
@@ -27,6 +27,7 @@
 @property (retain, nonatomic) IBOutlet UIToolbar* myToolbar;
 @property (retain, nonatomic) MKNumberBadgeView*  badgeSeven;
 @property (retain, nonatomic) MKNumberBadgeView*  badgeEight;
+@property (retain, nonatomic) MKNumberBadgeView*  badgeNine;
 
 -(IBAction)slideValueChanged:(id)sender;
 

--- a/Sample App/iPhoneMK Sample App/NumberBadgeViewController.m
+++ b/Sample App/iPhoneMK Sample App/NumberBadgeViewController.m
@@ -69,33 +69,57 @@
 
     // Badge Seven
     UIButton* buttonSeven = [[UIButton alloc] initWithFrame:CGRectMake(0, 0, 70, 30)];
-    buttonSeven.titleLabel.text = @"seven";
     [buttonSeven setTitle:@"seven" forState:UIControlStateNormal];
     [buttonSeven setBackgroundColor:[UIColor blueColor]];
     self.badgeSeven = [[MKNumberBadgeView alloc] initWithFrame:CGRectMake(buttonSeven.frame.size.width - 37,
                                                                           -15,
                                                                           74,
                                                                           30)];
+    self.badgeSeven.font = [UIFont boldSystemFontOfSize:11];
     [buttonSeven addSubview:self.badgeSeven];
 
-    // Badge Eight
+    // Badge Eight - Wrong way
     self.badgeEight = [[MKNumberBadgeView alloc] initWithFrame:CGRectMake(-22,
                                                                           -15,
                                                                           44,
                                                                           30)];
-    UISegmentedControl* segmentedControl =
-    [[UISegmentedControl alloc] initWithItems:@[@"9a",@"9b", @"9c"]];
-    [segmentedControl addSubview:self.badgeEight];
+    self.badgeEight.font = [UIFont boldSystemFontOfSize:11];
+    UISegmentedControl* segmentedControlEight =
+    [[UISegmentedControl alloc] initWithItems:@[@"9a",@"9b",@"9c"]];
+    segmentedControlEight.segmentedControlStyle = UISegmentedControlStyleBar;
+    segmentedControlEight.momentary = YES;
+    [segmentedControlEight addSubview:self.badgeEight];
+    UIBarButtonItem* buttonEight = [[UIBarButtonItem alloc] initWithCustomView:segmentedControlEight];
 
-    // Add buttons seven and eight to the toolbar
-    UIBarButtonItem* buttonEight = [[UIBarButtonItem alloc] initWithCustomView:segmentedControl];
+    // Badge Nine - Right Way
+    self.badgeNine = [[MKNumberBadgeView alloc] initWithFrame:CGRectMake(-22,
+                                                                         -15,
+                                                                         44,
+                                                                         30)];
+    self.badgeNine.font = [UIFont boldSystemFontOfSize:11];
+    UISegmentedControl* segmentedControlNine =
+    [[UISegmentedControl alloc] initWithItems:@[@"9a",@"9b",@"9c"]];
+    segmentedControlNine.segmentedControlStyle = UISegmentedControlStyleBar;
+    segmentedControlNine.momentary = YES;
+    //segmentedControlNine.tintColor = [UIColor blackColor]; // may need to be set explicitly because of container indirection
+    UIView* containerViewNine = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 90, 30)];
+    [containerViewNine addSubview:segmentedControlNine];
+    [containerViewNine addSubview:self.badgeNine];
+    UIBarButtonItem* buttonNine = [[UIBarButtonItem alloc] initWithCustomView:containerViewNine];
+
+    // Add seven, eight and nine to the toolbar
+    
     NSArray* toobarItems =
     @[
       [[UIBarButtonItem alloc] initWithCustomView:buttonSeven],
       [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace
                                                     target:nil
                                                     action:nil],
-      buttonEight
+      buttonEight,
+      [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace
+                                                    target:nil
+                                                    action:nil],
+      buttonNine
     ];
     [self.myToolbar setItems:toobarItems];
     
@@ -152,6 +176,7 @@
     self.badgeSix.value = sliderValue * 1000;
     self.badgeSeven.value = sliderValue * 1000;
     self.badgeEight.value = sliderValue;
+    self.badgeNine.value = sliderValue;
 }
 
 @end


### PR DESCRIPTION
In this pull request ... I've marked the right way and the wrong way of using a badge with a UISegmentedControl with your badge library. You don't have to put it into place that way, you can choose not to commit the few lines marked "wrong way" ... I only left it in place because my first reaction to a sample which seems to have extra lines (like the container view in "right way") is to optimize and remove them without realizing that there was a good reason to have them there. Guess I'm just protecting people like myself from making mistakes :)

I've also used a smaller font in badges just for the sake of smushing stuff together for demo.

I noticed that you made a change in your source recently from `UIExtendedEdgeNone` to `UIRectEdgeNone` ... can you tell me what that was about?
