### PR TITLE
Modernize calls to deprecated methods

### DIFF
--- a/Sample App/iPhoneMK Sample App.xcodeproj/project.pbxproj
+++ b/Sample App/iPhoneMK Sample App.xcodeproj/project.pbxproj
@@ -682,7 +682,7 @@
 				GCC_THUMB_SUPPORT = NO;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INFOPLIST_FILE = "iPhoneMK Sample App/iPhoneMK Sample App-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};
@@ -697,7 +697,7 @@
 				GCC_THUMB_SUPPORT = NO;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INFOPLIST_FILE = "iPhoneMK Sample App/iPhoneMK Sample App-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};

--- a/Views/MKNumberBadgeView/MKNumberBadgeView.m
+++ b/Views/MKNumberBadgeView/MKNumberBadgeView.m
@@ -233,15 +233,9 @@
 	CGContextRestoreGState( curContext );
 	CGPathRelease(badgePath);
 	
-	CGContextSaveGState( curContext );
-	CGContextSetFillColorWithColor( curContext, self.textColor.CGColor );
-		
 	CGPoint textPt = CGPointMake( ctm.x + (badgeRect.size.width - numberSize.width)/2 + self.adjustOffset.x, ctm.y + (badgeRect.size.height - numberSize.height)/2 + self.adjustOffset.y);
 	
-	[numberString drawAtPoint:textPt withAttributes:@{ NSFontAttributeName : self.font }];
-
-	CGContextRestoreGState( curContext );
-
+    [numberString drawAtPoint:textPt withAttributes:@{ NSFontAttributeName : self.font, NSForegroundColorAttributeName : self.textColor }];
 }
 
 

--- a/Views/MKNumberBadgeView/MKNumberBadgeView.m
+++ b/Views/MKNumberBadgeView/MKNumberBadgeView.m
@@ -127,7 +127,7 @@
 	NSString* numberString = [NSString stringWithFormat:self.textFormat,self.value];
 	
 	
-	CGSize numberSize = [numberString sizeWithFont:self.font];
+    CGSize numberSize = [numberString sizeWithAttributes:@{ NSFontAttributeName : self.font }];
 		
 	CGPathRef badgePath = [self newBadgePathForTextSize:numberSize];
 	
@@ -238,7 +238,7 @@
 		
 	CGPoint textPt = CGPointMake( ctm.x + (badgeRect.size.width - numberSize.width)/2 + self.adjustOffset.x, ctm.y + (badgeRect.size.height - numberSize.height)/2 + self.adjustOffset.y);
 	
-	[numberString drawAtPoint:textPt withFont:self.font];
+	[numberString drawAtPoint:textPt withAttributes:@{ NSFontAttributeName : self.font }];
 
 	CGContextRestoreGState( curContext );
 
@@ -286,7 +286,7 @@
 	NSString* numberString = [NSString stringWithFormat:self.textFormat,self.value];
 	
 	
-	CGSize numberSize = [numberString sizeWithFont:self.font];
+	CGSize numberSize = [numberString sizeWithAttributes:@{ NSFontAttributeName : self.font }];
 	
 	CGPathRef badgePath = [self newBadgePathForTextSize:numberSize];
 	


### PR DESCRIPTION
This Cocoapod called two deprecated methods, -[UIView sizeWithFont:] and -[UIView drawAtPoint:withAttributes:].  Those method calls have been modernized to their iOS 7+ equivalents.  This clears three deprecation warnings in the Raise iOS project.
